### PR TITLE
Fix apache remote ip

### DIFF
--- a/5.6.21-apache-2/Dockerfile
+++ b/5.6.21-apache-2/Dockerfile
@@ -5,7 +5,7 @@ COPY apache2.conf /bin/
 COPY init_container.sh /bin/
 COPY hostingstart.html /home/site/wwwroot/hostingstart.html
 
-RUN a2enmod rewrite expires include
+RUN a2enmod rewrite expires include remoteip
 
 # install the PHP extensions we need
 RUN apt update \ 

--- a/5.6.21-apache-2/apache2.conf
+++ b/5.6.21-apache-2/apache2.conf
@@ -12,6 +12,9 @@ HostnameLookups Off
 ErrorLog /var/log/apache2/error.log
 LogLevel warn
 
+RemoteIPHeader X-Client-IP
+RemoteIPTrustedProxy 172.17.0.0/8
+
 IncludeOptional mods-enabled/*.load
 IncludeOptional mods-enabled/*.conf
 
@@ -37,7 +40,7 @@ AccessFileName .htaccess
 </FilesMatch>
 
 LogFormat "%v:%p %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
-LogFormat "\"%{X-Client-IP}i\" %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "\"%a\" %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
 LogFormat "%h %l %u %t \"%r\" %>s %O" common
 LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent

--- a/5.6.21-apache-2/apache2.conf
+++ b/5.6.21-apache-2/apache2.conf
@@ -13,7 +13,6 @@ ErrorLog /var/log/apache2/error.log
 LogLevel warn
 
 RemoteIPHeader X-Client-IP
-RemoteIPTrustedProxy 172.17.0.0/8
 
 IncludeOptional mods-enabled/*.load
 IncludeOptional mods-enabled/*.conf

--- a/5.6.21-apache-2/apache2.conf
+++ b/5.6.21-apache-2/apache2.conf
@@ -38,9 +38,9 @@ AccessFileName .htaccess
 	Require all denied
 </FilesMatch>
 
-LogFormat "%v:%p %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
-LogFormat "\"%a\" %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
-LogFormat "%h %l %u %t \"%r\" %>s %O" common
+LogFormat "%v:%p %a %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
+LogFormat "%a %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "%a %l %u %t \"%r\" %>s %O" common
 LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
 

--- a/7.0.6-apache-2/Dockerfile
+++ b/7.0.6-apache-2/Dockerfile
@@ -5,7 +5,7 @@ COPY apache2.conf /bin/
 COPY init_container.sh /bin/
 COPY hostingstart.html /home/site/wwwroot/hostingstart.html
 
-RUN a2enmod rewrite expires include
+RUN a2enmod rewrite expires include remoteip
 
 # install the PHP extensions we need
 RUN apt-get update \

--- a/7.0.6-apache-2/apache2.conf
+++ b/7.0.6-apache-2/apache2.conf
@@ -12,6 +12,9 @@ HostnameLookups Off
 ErrorLog /var/log/apache2/error.log
 LogLevel warn
 
+RemoteIPHeader X-Client-IP
+RemoteIPTrustedProxy 172.17.0.0/8
+
 IncludeOptional mods-enabled/*.load
 IncludeOptional mods-enabled/*.conf
 
@@ -37,7 +40,7 @@ AccessFileName .htaccess
 </FilesMatch>
 
 LogFormat "%v:%p %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
-LogFormat "\"%{X-Client-IP}i\" %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "\"%a\" %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
 LogFormat "%h %l %u %t \"%r\" %>s %O" common
 LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent

--- a/7.0.6-apache-2/apache2.conf
+++ b/7.0.6-apache-2/apache2.conf
@@ -13,7 +13,6 @@ ErrorLog /var/log/apache2/error.log
 LogLevel warn
 
 RemoteIPHeader X-Client-IP
-RemoteIPTrustedProxy 172.17.0.0/8
 
 IncludeOptional mods-enabled/*.load
 IncludeOptional mods-enabled/*.conf

--- a/7.0.6-apache-2/apache2.conf
+++ b/7.0.6-apache-2/apache2.conf
@@ -38,9 +38,9 @@ AccessFileName .htaccess
 	Require all denied
 </FilesMatch>
 
-LogFormat "%v:%p %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
-LogFormat "\"%a\" %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
-LogFormat "%h %l %u %t \"%r\" %>s %O" common
+LogFormat "%v:%p %a %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
+LogFormat "%a %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "%a %l %u %t \"%r\" %>s %O" common
 LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
 


### PR DESCRIPTION
REMOTE_ADDR remains as internal IP in Built-in image.
I fixed it using apache's mod_remoteip
https://httpd.apache.org/docs/current/mod/mod_remoteip.html

### before
![before](https://cloud.githubusercontent.com/assets/1356444/26755612/89e467f0-48cb-11e7-861a-a73f38e4fd08.png)

### after
![after](https://cloud.githubusercontent.com/assets/1356444/26755610/7c0d3206-48cb-11e7-9283-e7c1e1a63a3e.png)
