### PR TITLE
Fix for application settings values for which equalTo or semi-colon symbol from values get remove.

### DIFF
--- a/5.6.36-apache/init_container.sh
+++ b/5.6.36-apache/init_container.sh
@@ -15,7 +15,7 @@ EOL
 cat /etc/motd
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -n 's/^\(.*\)$/export \1/p' >> /etc/profile)
 
 service ssh start
 sed -i "s/{PORT}/$PORT/g" /etc/apache2/apache2.conf

--- a/7.0.30-apache/init_container.sh
+++ b/7.0.30-apache/init_container.sh
@@ -15,7 +15,7 @@ EOL
 cat /etc/motd
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -n 's/^\(.*\)$/export \1/p' >> /etc/profile)
 
 service ssh start
 sed -i "s/{PORT}/$PORT/g" /etc/apache2/apache2.conf

--- a/7.2.5-apache/init_container.sh
+++ b/7.2.5-apache/init_container.sh
@@ -15,7 +15,7 @@ EOL
 cat /etc/motd
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -n 's/^\(.*\)$/export \1/p' >> /etc/profile)
 
 service ssh start
 sed -i "s/{PORT}/$PORT/g" /etc/apache2/apache2.conf


### PR DESCRIPTION
- Updated init_container.sh, mainly around how application settings (environment variables) are parsed.

- Issue with existing line of code is that if we add value in application settings which contains equalTo ('=') or semi-colon (';') in value they get removed.

for example: 
if you set Test_EQAUL with value of TEST===== in application settings.
     go to SSH using KUDU type
     `printenv | grep 'TEST_EQUAL'`
     you'll get `APPSETTINGS_Test_EQUAL=TEST` // here we loose all ===== symbols

Same is the case with semi-colon.